### PR TITLE
identified issues and didn't properly fix

### DIFF
--- a/Assets/Scripts/MapGenerator/MapGenerator.cs
+++ b/Assets/Scripts/MapGenerator/MapGenerator.cs
@@ -107,37 +107,37 @@ public class MapGenerator : MonoBehaviour
         {
             case 0: // bottom
                 validPos = (lastTilePos.x, lastTilePos.y - 1);
-                checkPos = (validPos.x, validPos.y - 2); // down
+                checkPos = (validPos.x, validPos.y - 1); // down
                 checkVectors.Add(checkPos);
-                checkPos = (validPos.x + 1, validPos.y - 1); // right
+                checkPos = (validPos.x + 1, validPos.y); // right
                 checkVectors.Add(checkPos);
-                checkPos = (validPos.x - 1, validPos.y - 1); // left
+                checkPos = (validPos.x - 1, validPos.y); // left
                 checkVectors.Add(checkPos);
                 break;
             case 1: // right
                 validPos = (lastTilePos.x + 1, lastTilePos.y);
-                checkPos = (validPos.x - 1, validPos.y - 1); // left
+                checkPos = (validPos.x + 1, validPos.y); // right
                 checkVectors.Add(checkPos);
-                checkPos = (validPos.x + 1, validPos.y - 1); // down
+                checkPos = (validPos.x, validPos.y - 1); // down
                 checkVectors.Add(checkPos);
-                checkPos = (validPos.x + 1, validPos.y + 1); // up
+                checkPos = (validPos.x, validPos.y + 1); // up
                 break;
             case 2: // top
                 validPos = (lastTilePos.x, lastTilePos.y + 1);
-                checkPos = (validPos.x, validPos.y + 2); // up
+                checkPos = (validPos.x, validPos.y + 1); // up
                 checkVectors.Add(checkPos);
-                checkPos = (validPos.x + 1, validPos.y + 1); // right
+                checkPos = (validPos.x + 1, validPos.y); // right
                 checkVectors.Add(checkPos);
-                checkPos = (validPos.x - 1, validPos.y + 1); // left
+                checkPos = (validPos.x - 1, validPos.y); // left
                 checkVectors.Add(checkPos);
                 break;
             case 3: // left
                 validPos = (lastTilePos.x - 1, lastTilePos.y);
-                checkPos = (validPos.x + 1, validPos.y - 1); // right
+                checkPos = (validPos.x - 1, validPos.y); // left
                 checkVectors.Add(checkPos);
-                checkPos = (validPos.x - 1, validPos.y - 1); // down
+                checkPos = (validPos.x, validPos.y - 1); // down
                 checkVectors.Add(checkPos);
-                checkPos = (validPos.x - 1, validPos.y + 1); // up
+                checkPos = (validPos.x, validPos.y + 1); // up
                 checkVectors.Add(checkPos);
                 break;
         }
@@ -189,10 +189,11 @@ public class MapGenerator : MonoBehaviour
         TileSetGenerator tileSetGen;
         if(availableDirections.Count == 0 || availableDirections.Count == 3) { 
             // direction won't matter, just pick a random one
-            Debug.Log("No available directions after.");
+            Debug.Log("Any direction is available.");
             tileSetGen = new TileSetGenerator(tilesetWidth, tilesetHeight, genStitchTile);
         } else {
-            int rand = Random.Range(0, availableDirections.Count);
+            int rand = UnityEngine.Random.Range(0, availableDirections.Count);
+            Debug.Log($"Random number: {rand}");
             int randDir = availableDirections[rand];
             Debug.Log($"Random direction: {randDir}");
             tileSetGen = new TileSetGenerator(tilesetWidth, tilesetHeight, genStitchTile, randDir);

--- a/Assets/Scripts/MapGenerator/TileSetGenerator.cs
+++ b/Assets/Scripts/MapGenerator/TileSetGenerator.cs
@@ -104,10 +104,10 @@ public class TileSetGenerator
             tileSet.DirCardinals.end = 0;
             tileSet.endTile.position.y = 0;
         } else if(tileSet.endTile.position.x == 0) {
-            tileSet.DirCardinals.end = 3;
+            tileSet.DirCardinals.end = 1;
             tileSet.endTile.position.x = tileSetWidth - 1;
         } else if(tileSet.endTile.position.x == (tileSetWidth-1)) {
-            tileSet.DirCardinals.end = 1;
+            tileSet.DirCardinals.end = 3;
             tileSet.endTile.position.x = 0;
         }
 
@@ -197,8 +197,8 @@ public class TileSetGenerator
                                         // this is to keep the same capability as before
             tileSet.DirCardinals.start = UnityEngine.Random.Range(0,4); // get the cardinals
 
-            if(tileSet.DirCardinals.end == tileSet.DirCardinals.start){
-                while(tileSet.DirCardinals.end == tileSet.DirCardinals.start) {
+            if(tileSet.DirCardinals.start == tileSet.DirCardinals.end){
+                while(tileSet.DirCardinals.start == tileSet.DirCardinals.end) {
                     tileSet.DirCardinals.start = UnityEngine.Random.Range(0,4);
                 }
             }


### PR DESCRIPTION
I had noticed in an issue with path generation during further playtesting of the map generation.

![image](https://user-images.githubusercontent.com/40471000/195965469-284daa42-a244-479d-b524-6f379976e19e.png)

Not exactly a good example picture, simply taking from the relevant closed pull request, but I had noticed that the start and end tiles were spawning in the same direction. Entirely unintended behavior as I don't want the potential of crossing paths as I improve upon the path generation.

Now the path generation simply follows along how I was desiring to end up:

![image](https://user-images.githubusercontent.com/40471000/195965513-a7c5ec99-1651-4040-ae6e-e18d71315c8d.png)
